### PR TITLE
Skip empty files

### DIFF
--- a/src/camel_snake_pep8/camel_snake_pep8.py
+++ b/src/camel_snake_pep8/camel_snake_pep8.py
@@ -441,6 +441,8 @@ def rope_iterate_worder(source_file_name, fun_name_defs=False, fun_arguments=Fal
         class_names = True
 
     source_string = get_source_string(source_file_name)
+    if not source_string:
+        return []
     w = worder.Worder(source_string)
 
     possible_changes = []


### PR DESCRIPTION
Currently if you have an empty `.py` file the script fails to run. This checks to make sure that the file isn't empty before trying to analyze it.